### PR TITLE
pick oommf with extensions as default package

### DIFF
--- a/spack/package.py
+++ b/spack/package.py
@@ -42,6 +42,18 @@ class Oommf(Package):
     maintainers = ["fangohr"]
 
     version(
+        "20b0_20220930",
+        sha256="764f1983d858fbad4bae34c720b217940ce56f745647ba94ec74de4b185f1328",
+        preferred=True
+    )
+
+    version(
+        "20b0_20220930-vanilla",
+        url="https://math.nist.gov/oommf/dist/oommf20b0_20220930.tar.gz",
+        sha256="141826208d638ded65704d0964d9c56e94a35d198e310454f6173e02601378fd",
+    )
+
+    version(
         "20a3_20210930",
         sha256="880242afdf4c84de7f2a3c42ab0ad8c354028a7d2d3c3160980cf3e08e285691",
     )
@@ -108,7 +120,7 @@ class Oommf(Package):
 
     # sanity checks: (https://spack.readthedocs.io/en/latest/packaging_guide.html#checking-an-installation)
     sanity_check_is_file = [join_path("bin", "oommf.tcl")]
-    sanity_check_is_dir = ["usr/bin/oommf/app", "usr/bin/oommf/app/oxs/eamples"]
+    sanity_check_is_dir = ["usr/bin/oommf/app", "usr/bin/oommf/app/oxs/examples"]
 
     def get_oommf_source_root(self):
         """If we download the source from NIST, then 'oommf.tcl' is in the root directory.


### PR DESCRIPTION
- includes merge of spack upstream (new versions, typo fix)